### PR TITLE
Cache api requests

### DIFF
--- a/app/controllers/api/portfolios_controller.rb
+++ b/app/controllers/api/portfolios_controller.rb
@@ -1,8 +1,14 @@
+require 'net/http'
+
 class Api::PortfoliosController < ApplicationController
     def index
         @portfolio = Portfolio.where(user_id: params[:user_id])
         # byebug
         render :index
+    end
+
+    def portfolio_value
+        render json: current_user.portfolio_value
     end
 
     def create

--- a/app/models/daily_stock_quote.rb
+++ b/app/models/daily_stock_quote.rb
@@ -25,4 +25,25 @@ class DailyStockQuote < ApplicationRecord
             data: data
         )]
     end
+
+    def construct_stock_daily_graph
+        chart = []
+        last_price = nil
+
+        (30.days.ago.to_i..Time.now.to_i).step(1.day).each do |seconds|
+            date_time = Time.at(seconds) 
+
+            value_at_date = self.data["Time Series (Daily)"].dig(date_time.strftime("%Y-%m-%d"))
+
+            if value_at_date
+                value = value_at_date["4. close"] ? value_at_date["4. close"] : value_at_date["1. open"]
+                chart << { label: date_time.strftime("%Y-%m-%d"), vw: value}
+                last_price = value
+            else
+                chart << { label: date_time.strftime("%Y-%m-%d"), vw: last_price}
+            end
+        end
+
+        chart
+    end
 end

--- a/app/models/daily_stock_quote.rb
+++ b/app/models/daily_stock_quote.rb
@@ -1,5 +1,28 @@
+require "net/http"
+
 class DailyStockQuote < ApplicationRecord
     validates_presence_of :date_start, :date_end, :data
     
     belongs_to :stock
+
+    def self.fetch_daily_data(stock_ticker)
+        stock = Stock.find_by_symbol(stock_ticker)
+        if stock.blank?
+            throw "Stock doesn't exist in database"
+        end
+
+        uri = URI.parse "https://www.alphavantage.co/query?function=TIME_SERIES_DAILY&symbol=#{stock_ticker}&apikey=#{ENV['ALPHA_VANTAGE_KEY']}"
+        response = Net::HTTP.get_response uri
+        data = JSON.parse response.body
+
+        date_start = data['Time Series (Daily)'].keys.last
+        date_end = data['Time Series (Daily)'].keys.first
+        
+        [DailyStockQuote.create(
+            date_start: date_start,
+            date_end: date_end,
+            stock: stock,
+            data: data
+        )]
+    end
 end

--- a/app/models/daily_stock_quote.rb
+++ b/app/models/daily_stock_quote.rb
@@ -1,0 +1,5 @@
+class DailyStockQuote < ApplicationRecord
+    validates_presence_of :date_start, :date_end, :data
+    
+    belongs_to :stock
+end

--- a/app/models/stock.rb
+++ b/app/models/stock.rb
@@ -1,4 +1,5 @@
 class Stock < ApplicationRecord
     validates :symbol, uniqueness: true
 
+    has_many :daily_stock_quotes
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -72,7 +72,7 @@ class User < ApplicationRecord
         arr = []
         (30.days.ago.to_i..Time.now.to_i).step(1.day).each do |seconds|
             date_time = Time.at(seconds) 
-
+            
             previous_transactions = portfolios.filter {|transaction| transaction[:created_at] <= date_time.utc}
             value = 0
             previous_transactions.each do |transaction|

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -62,23 +62,9 @@ class User < ApplicationRecord
             cached_quote = stock.daily_stock_quotes.where('date_end >= ?', Date.today.beginning_of_day)
             if cached_quote.present?
                 hash[stock.symbol] = cached_quote.first.data["Time Series (Daily)"]
-
             else
-                # If an existing quote doesn't exist, save it
-                uri = URI.parse("https://www.alphavantage.co/query?function=TIME_SERIES_DAILY&symbol=#{stock.symbol}&apikey=#{ENV['ALPHA_VANTAGE_KEY']}")
-                response = Net::HTTP.get_response uri
-                data = JSON.parse response.body
-        
-                date_start = data['Time Series (Daily)'].keys.last
-                date_end = data['Time Series (Daily)'].keys.first
-
-                quote = DailyStockQuote.create(
-                    date_start: date_start,
-                    date_end: date_end,
-                    stock: stock,
-                    data: data
-                )
-                hash[stock.symbol] = data["Time Series (Daily)"]
+                quote = DailyStockQuote.fetch_daily_data stock.symbol
+                hash[stock.symbol] = quote.first.data["Time Series (Daily)"]
             end
         end
 

--- a/app/views/api/stocks/index.json.jbuilder
+++ b/app/views/api/stocks/index.json.jbuilder
@@ -17,6 +17,7 @@ ownedStocks = current_user.stocks.pluck(:symbol)
 
         # Fetch an existing quote from the DB, otherwise from the API
         quote = stock.daily_stock_quotes.where("date_end >= ?", Date.today.beginning_of_day)
+        
         quote = DailyStockQuote.fetch_daily_data stock.symbol if quote.blank?
 
         data = quote.first.data["Time Series (Daily)"]

--- a/app/views/api/stocks/index.json.jbuilder
+++ b/app/views/api/stocks/index.json.jbuilder
@@ -23,19 +23,7 @@ ownedStocks = current_user.stocks.pluck(:symbol)
     
         chart = []
         if quote.blank?
-            uri = URI.parse "https://www.alphavantage.co/query?function=TIME_SERIES_DAILY&symbol=#{stock.symbol}&apikey=#{ENV['ALPHA_VANTAGE_KEY']}"
-            response = Net::HTTP.get_response uri
-            data = JSON.parse response.body
-
-            date_start = data['Time Series (Daily)'].keys.last
-            date_end = data['Time Series (Daily)'].keys.first
-            
-            quote = [DailyStockQuote.create(
-                date_start: date_start,
-                date_end: date_end,
-                stock: stock,
-                data: data
-            )]
+            quote = DailyStockQuote.fetch_daily_data stock.symbol
         end        
 
         data = quote.first.data["Time Series (Daily)"]

--- a/app/views/api/stocks/show.json.jbuilder
+++ b/app/views/api/stocks/show.json.jbuilder
@@ -1,13 +1,7 @@
 require 'net/http'
 require 'uri'
 require 'json'
-require_relative '../shared/sample_state'
 require_relative '../shared/news_api'
-require_relative '../shared/stock_parser'
-
-# this uri uses the sandbox & test key
-stockParser = StockParser.new(@stock.symbol)
-
 quote = @stock.daily_stock_quotes.where('date_end >= ?', Date.today.beginning_of_day)
 
 if quote.blank?
@@ -16,38 +10,28 @@ end
     
 chart = quote.first.construct_stock_daily_graph
 
-price = stockParser.getPrice
-
-# price = stockParser.getPrice
-# chart = stockParser.getDefaultChart
-dollarChange = stockParser.getDollarChange
-percentageChange = stockParser.getPercentageChange
-# uri = URI.parse("https://sandbox.iexapis.com/stable/stock/market/batch?types=news,price&symbols=#{@stock.symbol}&token=#{ENV['TEST_IEX_KEY']}")
-# # uri = URI.parse("https://sandbox.iexapis.com/stable/stock/market/batch?types=chart&symbols=fb&range=1d&token=#{ENV['TEST_IEX_KEY']}")
-# priceNewsresponse = Net::HTTP.get_response(uri)
-#JSON.parse(response.body)['FB']['chart']
-
-
-
-
 # this pulls about copmany
 aboutUri = URI.parse("https://api.polygon.io/v3/reference/tickers/#{@stock.symbol}?apiKey=#{ENV['POLYGON_KEY']}")
-# aboutUri = URI.parse("https://cloud.iexapis.com/stable/stock/#{@stock.symbol}/company?token=#{ENV['REAL_IEX_KEY']}")
-# aboutUri = URI.parse("https://sandbox.iexapis.com/stable/stock/#{@stock.symbol}/company?token=#{ENV['TEST_IEX_KEY']}")
-#uri = URI.parse("https://sandbox.iexapis.com/stable/stock/market/batch?types=chart&symbols=fb&range=1d&token=#{ENV['TEST_IEX_KEY']}")
 aboutResponse = Net::HTTP.get_response(aboutUri)
 
 json.set! @stock.symbol do
     json.symbol @stock.symbol
 
-    json.price quote.first.data["Time Series (Daily)"].values.first["1. open"]
 
     json.chart chart
 
+    data = quote.first.data["Time Series (Daily)"].values
+
+    current_price = (data.first["4. close"] ? data.first["4. close"] : data.first["1. open"]).to_f
+    previous_price = (data.second["4. close"] ? data.second["4. close"] : data.second["1. open"]).to_f
+
+    json.price current_price
     # set the dollar and percentage change for the day based on current price
     # using last price of the chart for current price
-    json.dollarChange dollarChange
-    json.percentageChange percentageChange
+    json.dollarChange current_price - previous_price
+
+    percentage_change = ((current_price - previous_price) / previous_price * 100).round(2)
+    json.percentageChange percentage_change
 
     news = NewsAPI.new(@stock.company)
     company_news = news.fetch # pulls 
@@ -55,5 +39,4 @@ json.set! @stock.symbol do
     
     about = JSON.parse(aboutResponse.body)["results"] # 
     json.about about
-
 end

--- a/app/views/api/stocks/show.json.jbuilder
+++ b/app/views/api/stocks/show.json.jbuilder
@@ -7,14 +7,14 @@ require_relative '../shared/stock_parser'
 
 # this uri uses the sandbox & test key
 stockParser = StockParser.new(@stock.symbol)
-chart = stockParser.chart
-chart.each_with_index do |chartItem, idx|
-    
-    if chartItem['average'] == nil
-        
-        chart[idx]['average'] = chart[idx-1]['average'] || chart[idx-2]['average'] 
-    end
+
+quote = @stock.daily_stock_quotes.where('date_end >= ?', Date.today.beginning_of_day)
+
+if quote.blank?
+    quote = DailyStockQuote.fetch_daily_data @stockstock.symbol @stock.construct_stock_daily_graph
 end
+    
+chart = quote.first.construct_stock_daily_graph
 
 price = stockParser.getPrice
 
@@ -40,12 +40,10 @@ aboutResponse = Net::HTTP.get_response(aboutUri)
 json.set! @stock.symbol do
     json.symbol @stock.symbol
 
-    json.price price
+    json.price quote.first.data["Time Series (Daily)"].values.first["1. open"]
 
     json.chart chart
 
-    # chart
-    
     # set the dollar and percentage change for the day based on current price
     # using last price of the chart for current price
     json.dollarChange dollarChange

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,7 +5,9 @@ Rails.application.routes.draw do
     resources :watchlists, only: [:index, :create, :destroy]
     resources :watched_stocks, only: [:create, :destroy]
     resources :users, only: [:create] do
-      resources :portfolios, param: :symbol, only: [:index, :update]
+      get 'portfolio_value', to: 'portfolios#portfolio_value'
+
+      resources :portfolios, param: :symbol, only: [:index, :update] 
     end
     resources :stocks, param: :symbol, only: [:show, :index]
     resource :session, only: [:create, :destroy]

--- a/db/migrate/20241007220629_create_daily_stock_quotes.rb
+++ b/db/migrate/20241007220629_create_daily_stock_quotes.rb
@@ -1,0 +1,12 @@
+class CreateDailyStockQuotes < ActiveRecord::Migration[6.1]
+  def change
+    create_table :daily_stock_quotes do |t|
+      t.belongs_to :stock
+      t.json :data
+      t.datetime :date_start
+      t.datetime :date_end
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,10 +10,20 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2024_01_17_004743) do
+ActiveRecord::Schema.define(version: 2024_10_07_220629) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "daily_stock_quotes", force: :cascade do |t|
+    t.bigint "stock_id"
+    t.json "data"
+    t.datetime "date_start"
+    t.datetime "date_end"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["stock_id"], name: "index_daily_stock_quotes_on_stock_id"
+  end
 
   create_table "portfolios", force: :cascade do |t|
     t.integer "user_id", null: false

--- a/frontend/components/dashboard/dashboard.jsx
+++ b/frontend/components/dashboard/dashboard.jsx
@@ -51,14 +51,22 @@ const Dashboard = () => {
       <main className="functional-component-container">
         <section className="main">
           <div className="functional-component-container-top">
-            <GraphComponent stock={{ chart: portfolioValues }} />
-            {/* <GraphComponent
-              stock={
-                history
-                  ? constructPortfolioGraph(history, portfolios, stocks)
-                  : {}
-              }
-            /> */}
+            <GraphComponent
+              stock={{
+                percentageChange: (
+                  ((portfolioValues[portfolioValues.length - 1].vw -
+                    portfolioValues[portfolioValues.length - 2].vw) /
+                    portfolioValues[portfolioValues.length - 2].vw) *
+                  100
+                ).toFixed(2),
+                dollarChange: (
+                  portfolioValues[portfolioValues.length - 1].vw -
+                  portfolioValues[portfolioValues.length - 2].vw
+                ).toFixed(2),
+                price: portfolioValues[portfolioValues.length - 1].vw,
+                chart: portfolioValues,
+              }}
+            />
             <aside className="stock-sidebar-container">
               <DashMainSidebar stocks={stocks} portfolios={portfolios} />
             </aside>

--- a/frontend/components/dashboard/dashboard.jsx
+++ b/frontend/components/dashboard/dashboard.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from "react";
+import React, { useEffect, useState } from "react";
 import DashMainSidebar from "../dashboard/dash_main_sidebar_container";
 import Loader from "../other/loader";
 import NewsComponent from "../other/NewsComponent";
@@ -9,15 +9,21 @@ import DashNavBar from "../nav/dash_nav_bar";
 import { fetchPortfolios } from "../../actions/portfolio_actions";
 import DashboardContent from "./DashboardContent";
 import { constructPortfolioGraph } from "../util/dashboardUtil";
+import { portfolioValue } from "../../util/portfolio_util";
 
 const Dashboard = () => {
   const dispatch = useDispatch();
   const currentUser = useSelector((state) => state.session.id);
   const stockLoader = useSelector((state) => state.loading.stockLoader);
+  const [portfolioValues, setPortfolioValues] = useState([]);
 
   useEffect(() => {
     dispatch(fetchPortfolios(currentUser));
     dispatch(fetchStocks());
+  }, []);
+
+  useEffect(() => {
+    portfolioValue(currentUser).then((data) => setPortfolioValues(data));
   }, []);
 
   const user = useSelector((state) => state.session.id);
@@ -28,6 +34,7 @@ const Dashboard = () => {
   });
   const history = portfolios.history;
 
+  if (portfolioValues.length === 0) return null;
   if (!portfolios || !user || !stocks) return null;
   if (!currentUser || !Object.keys(stocks).length) return null;
 
@@ -44,13 +51,14 @@ const Dashboard = () => {
       <main className="functional-component-container">
         <section className="main">
           <div className="functional-component-container-top">
-            <GraphComponent
+            <GraphComponent stock={{ chart: portfolioValues }} />
+            {/* <GraphComponent
               stock={
                 history
                   ? constructPortfolioGraph(history, portfolios, stocks)
                   : {}
               }
-            />
+            /> */}
             <aside className="stock-sidebar-container">
               <DashMainSidebar stocks={stocks} portfolios={portfolios} />
             </aside>

--- a/frontend/components/other/graph_component.jsx
+++ b/frontend/components/other/graph_component.jsx
@@ -35,9 +35,8 @@ const GraphComponent = (props) => {
   ]);
 
   const handleEnter = (e) => {
-    // debugger;
     if (!e.activePayload || !e.activePayload[0].value) return null;
-    setPrice(e.activePayload[0].value.toFixed(2));
+    setPrice(parseFloat(e.activePayload[0].value));
     setDollarChange(
       (e.activePayload[0].value - props.stock.chart[0].vw).toFixed(2)
     );

--- a/frontend/components/stock_show/stock_show.jsx
+++ b/frontend/components/stock_show/stock_show.jsx
@@ -23,7 +23,6 @@ const StockShow = () => {
   const symbol = match.params.symbol.toUpperCase();
 
   useEffect(() => {
-    dispatch(fetchStocks());
     dispatch(fetchStock(symbol));
     dispatch(fetchPortfolios(currentUser));
   }, [dispatch]);

--- a/frontend/components/stock_show/stock_show.jsx
+++ b/frontend/components/stock_show/stock_show.jsx
@@ -1,14 +1,12 @@
-import React, { Component, useEffect } from "react";
+import React, { useEffect } from "react";
 import GraphComponent from "../other/graph_component";
 import AboutComponent from "./about_component";
 import NewsComponent from "./news_component";
-import { Link, useMatch } from "react-router-dom";
-import Loading from "../other/loader";
+import { useMatch } from "react-router-dom";
 import { useDispatch, useSelector } from "react-redux";
 import { fetchStock } from "../../actions/stock_actions";
 import DashNavBar from "../nav/dash_nav_bar";
 import { fetchPortfolios } from "../../actions/portfolio_actions";
-import { fetchStocks } from "../../actions/stock_actions";
 import StockShowSidebar from "./stock_show_sidebar";
 
 const StockShow = () => {
@@ -29,6 +27,7 @@ const StockShow = () => {
 
   const stocks = useSelector((state) => state.entities.stocks);
   const stock = stocks[symbol];
+
   const portfolios = useSelector((state) => {
     return state.entities.portfolios;
   });

--- a/frontend/util/portfolio_util.jsx
+++ b/frontend/util/portfolio_util.jsx
@@ -18,3 +18,9 @@ export const updatePortfolio = (portfolio) => {
     data: { portfolio },
   });
 };
+
+export const portfolioValue = (currentUser) => {
+  return $.ajax({
+    url: `api/users/${currentUser}/portfolio_value`,
+  });
+};


### PR DESCRIPTION
With Alpha Vantage, I can only make 25 API requests a day. As a work around, I will Cache the first request for the day, and use that for subsequent information for a particular stock.