### PR TITLE
Fix blank page when exceeding API requests

### DIFF
--- a/app/views/api/stocks/show.json.jbuilder
+++ b/app/views/api/stocks/show.json.jbuilder
@@ -11,12 +11,14 @@ end
 chart = quote.first.construct_stock_daily_graph
 
 # this pulls about copmany
+
+# NEED TO CACHE THE ABOUT API REQUEST IN ORDER TO AVOID RECEIVING NO DATA
+
 aboutUri = URI.parse("https://api.polygon.io/v3/reference/tickers/#{@stock.symbol}?apiKey=#{ENV['POLYGON_KEY']}")
 aboutResponse = Net::HTTP.get_response(aboutUri)
 
 json.set! @stock.symbol do
     json.symbol @stock.symbol
-
 
     json.chart chart
 
@@ -37,6 +39,6 @@ json.set! @stock.symbol do
     company_news = news.fetch # pulls 
     json.news company_news
     
-    about = JSON.parse(aboutResponse.body)["results"] # 
+    about = JSON.parse(aboutResponse.body)
     json.about about
 end

--- a/frontend/components/stock_show/about_component.jsx
+++ b/frontend/components/stock_show/about_component.jsx
@@ -2,10 +2,21 @@ import React from "react";
 
 export default ({ about }) => {
   if (!about) return null;
+  if (about.status === "ERROR") {
+    return (
+      <section className="about">
+        <p>
+          The 5 requests per minute limit for company information has been
+          exceeded, please wait a bit before checking back.
+        </p>
+      </section>
+    );
+  }
+
   return (
     <section className="about">
       <h1>About</h1>
-      <p>{about.description}</p>
+      <p>{about.results.description}</p>
       <table className="general">
         <tbody>
           <tr>
@@ -15,12 +26,12 @@ export default ({ about }) => {
             <th>Website</th>
           </tr>
           <tr>
-            <td>{about.market_cap}</td>
-            <td>{about.total_employees}</td>
-            <td>{about.address.state}</td>
+            <td>{about.results.market_cap}</td>
+            <td>{about.results.total_employees}</td>
+            <td>{about.results.address.state}</td>
             <td>
-              <a target="_blank" href={about.homepage_url}>
-                {about.name}
+              <a target="_blank" href={about.results.homepage_url}>
+                {about.results.name}
               </a>
             </td>
           </tr>


### PR DESCRIPTION
The free tier of Polygon API only allows 5 API requests per minute (this API is used to fetch information about the stock's company).