### PR TITLE
Use Time instead of Date when searching for existing quote

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -59,7 +59,7 @@ class User < ApplicationRecord
 
         stocks.each do |stock|
             # first check if the API results have been persisted to the DB
-            cached_quote = stock.daily_stock_quotes.where('date_end >= ?', Date.today.beginning_of_day)
+            cached_quote = stock.daily_stock_quotes.where('date_end >= ?', Time.now.utc.beginning_of_day)
             if cached_quote.present?
                 hash[stock.symbol] = cached_quote.first.data["Time Series (Daily)"]
             else

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -59,7 +59,7 @@ class User < ApplicationRecord
 
         stocks.each do |stock|
             # first check if the API results have been persisted to the DB
-            cached_quote = stock.daily_stock_quotes.where('date_end >= ?', Time.now.utc.beginning_of_day)
+            cached_quote = stock.daily_stock_quotes.where('created_at >= ?', Time.now.utc.beginning_of_day)
             if cached_quote.present?
                 hash[stock.symbol] = cached_quote.first.data["Time Series (Daily)"]
             else

--- a/app/views/api/stocks/index.json.jbuilder
+++ b/app/views/api/stocks/index.json.jbuilder
@@ -16,7 +16,7 @@ ownedStocks = current_user.stocks.pluck(:symbol)
         json.extract! stock, :symbol, :company, :id
 
         # Fetch an existing quote from the DB, otherwise from the API
-        quote = stock.daily_stock_quotes.where("date_end >= ?", Time.now.utc.beginning_of_day)
+        quote = stock.daily_stock_quotes.where("created_at >= ?", Time.now.utc.beginning_of_day)
         
         quote = DailyStockQuote.fetch_daily_data stock.symbol if quote.blank?
 

--- a/app/views/api/stocks/index.json.jbuilder
+++ b/app/views/api/stocks/index.json.jbuilder
@@ -16,7 +16,7 @@ ownedStocks = current_user.stocks.pluck(:symbol)
         json.extract! stock, :symbol, :company, :id
 
         # Fetch an existing quote from the DB, otherwise from the API
-        quote = stock.daily_stock_quotes.where("date_end >= ?", Date.today.beginning_of_day)
+        quote = stock.daily_stock_quotes.where("date_end >= ?", Time.now.utc.beginning_of_day)
         
         quote = DailyStockQuote.fetch_daily_data stock.symbol if quote.blank?
 

--- a/app/views/api/stocks/show.json.jbuilder
+++ b/app/views/api/stocks/show.json.jbuilder
@@ -3,7 +3,7 @@ require 'uri'
 require 'json'
 require_relative '../shared/news_api'
 
-quote = @stock.daily_stock_quotes.where('date_end >= ?', Date.today.beginning_of_day)
+quote = @stock.daily_stock_quotes.where('date_end >= ?', Time.now.utc.beginning_of_day)
 
 if quote.blank?
     quote = DailyStockQuote.fetch_daily_data @stock.symbol

--- a/app/views/api/stocks/show.json.jbuilder
+++ b/app/views/api/stocks/show.json.jbuilder
@@ -3,7 +3,7 @@ require 'uri'
 require 'json'
 require_relative '../shared/news_api'
 
-quote = @stock.daily_stock_quotes.where('date_end >= ?', Time.now.utc.beginning_of_day)
+quote = @stock.daily_stock_quotes.where('created_at >= ?', Time.now.utc.beginning_of_day)
 
 if quote.blank?
     quote = DailyStockQuote.fetch_daily_data @stock.symbol


### PR DESCRIPTION
The server uses UTC as local time, so there was a problem when searching for an existing quote late in the day in PST time, when the server time was already on the next day (in this case, there could never be a quote found on the current day, since the `Date.today` was searching for quotes ending the previous day, I.e. `Date.today` was 2024/10/10 but the persisted quote was date end on 2024/10/11).

For example:
If a quote was persisted late in the day PST time, it would be saved in the database according to the fetched quotes JSON data (e.g., 2024/10/10), but the server's time would be looking for dates greater than its UTC time at the start of the day (e.g. 2024/10/11). In this scenario, it would be impossible to find the existing quote since it was recorded for the previous day (corresponding to the object key returned by Alpha Vantage). 

By searching for existing quotes using UTC, the conversion will hopefully prevent repeat API pings.